### PR TITLE
Updated version of log4j to 2.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.5.5'
+  id 'org.springframework.boot' version '2.5.7'
   id 'org.owasp.dependencycheck' version '6.0.3'
   id 'org.sonarqube' version '3.0'
   id 'com.github.ben-manes.versions' version '0.39.0'

--- a/build.gradle
+++ b/build.gradle
@@ -205,3 +205,5 @@ rootProject.tasks.named("processSmokeTestResources") {
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
+
+ext['log4j2.version'] = '2.15.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,13 +24,6 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   file name: spring-core-5.3.6.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-    <cve>CVE-2021-22118</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
    file name: spring-security-crypto-5.4.6.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
@@ -38,30 +31,9 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-   file name: tomcat-embed-core-9.0.53.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.53</packageUrl>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.53.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.53</packageUrl>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
    file name: jakarta.el-3.0.3.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org.glassfish/jakarta.el@3.0.3</packageUrl>
     <cve>CVE-2021-28170</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-core-5.3.10.jar
-   ]]></notes>
-    <packageUrl regex="true">pkg:maven/org.springframework/spring-core@5.3.10</packageUrl>
-    <cve>CVE-2021-22096</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Updated version of log4j to 2.15.0 following vulnerability in library

See https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot for details.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
