### PR TITLE
Pub 1000 change to postgres for local tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,7 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
    implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
 
+  testImplementation "io.zonky.test:embedded-database-spring-test:2.1.1"
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'
@@ -180,8 +181,6 @@ dependencies {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
-
-  testImplementation 'com.h2database:h2'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/GetWelcomeTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pip.subscription.management.controllers;
 
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @ActiveProfiles(profiles = "test")
+@AutoConfigureEmbeddedDatabase(type = AutoConfigureEmbeddedDatabase.DatabaseType.POSTGRES)
 class GetWelcomeTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.pip.subscription.management.controllers;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles(profiles = "test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@AutoConfigureEmbeddedDatabase(type = AutoConfigureEmbeddedDatabase.DatabaseType.POSTGRES)
 class SubscriptionControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/src/integrationTest/resources/application-test.yaml
+++ b/src/integrationTest/resources/application-test.yaml
@@ -1,9 +1,1 @@
-spring:
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb
-    username: my-db
-    password: my-db
-    embedded-directory: build
-    jpa:
-      spring.jpa.database-platform: org.hibernate.dialect.H2Dialect
+


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-1000


### Change description ###
Added Postgres and removed H2 dependencies, similar to the equivalent [data management PR](https://github.com/hmcts/pip-data-management/pull/38)
All tests should run without error now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
