### PR TITLE
Pub 738 - append updated subscriptions model to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,66 @@ Here are some other functionalities it provides:
  * [Request caching](https://github.com/Netflix/Hystrix/wiki/How-it-Works#request-caching), allowing
  different code paths to execute Hystrix Commands without worrying about duplicating work
 
+## API
+This service exposes various RESTful api's that help complete its purpose. Below is a list of endpoints and their
+operations.
+
+POST `/subscription` - Creates a new unique subscription based on a valid JSON body conforming to the [Subscription
+model](#subscription-model). Returns 201
+on success with a message of "Subscription successfully created with the
+id: {subscription id}" or 400 on invalid payload
+
+DELETE `/subscription/{subscriptionId}` - Deletes a subscription from the database that matches the subscription ID.
+Returns a 200 on success with the message "Subscription: {subId} was deleted" or 404 if the supplied ID was not found.
+
+GET - `/subscription/{subscriptionId}` - Returns a single subscription based on the subscription ID. Returns a 200
+on success or a 404 if the subscription ID was not found.
+
+GET - `/subscription/user/{userId}` - Returns a [User Subscription Model](#usersubscription-model) containing the
+cases and courts a user is subscribed to. Returns a 200 on success.
+
+
+## Models
+Various models are used to build the objects needed to send and receive data, see models used in Subscription
+Management below.
+
+### Subscription Model
+Subscription model representing the incoming data, please note that `ID`, `createdDate` and `courtName` are attributes
+that exist in this model but are created automatically once the object has been received.
+
+```json
+{
+  "userId": "ID of the user, linking to the user table",
+  "searchType": "ENUM of searchType",
+  "searchValue": "The Search value that is used against the search type",
+  "channel": "ENUM of the channel the user is to receive subscriptions by",
+  "caseNumber": "Case number of the case being subscribed to",
+  "caseName": "Name of the case being subscribed to",
+  "urn": "URN number being subscribed to"
+}
+```
+
+### UserSubscription Model
+
+```json
+{
+  "caseSubscriptions": [
+    {
+      "caseName": "Name of the case",
+      "caseNumber": "Case number of the case being subscribed to",
+      "urn": "URN number being subscribed to",
+      "dateAdded": "LocalDateTime of when the subscription was created"
+    }
+  ],
+  "courtSubscriptions": [
+    {
+      "courtName": "Name of the court being subscribed to",
+      "dateAdded": "LocalDateTime of when the subscription was created"
+    }
+  ]
+}
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/GetWelcomeTest.java
@@ -17,7 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = {Application.class},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles(profiles = "test")
+@ActiveProfiles(profiles = "integration")
 class GetWelcomeTest {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
@@ -37,14 +37,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = {Application.class, RestTemplateConfig.class},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles(profiles = "test")
+@ActiveProfiles(profiles = "integration")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class SubscriptionControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static SubscriptionDto subscription;
 
-    private static final String COURT_NAME_1 = "Glasgow-Court-1";
+    private static final String COURT_NAME_1 = "Blackpool Magistrates' Court";
     private static final String UUID_STRING = "f54c9783-7f56-4a69-91bc-55b582c0206f";
 
     private static final String VALIDATION_EMPTY_RESPONSE = "Returned response is empty";
@@ -53,6 +52,10 @@ class SubscriptionControllerTest {
     private static final String VALIDATION_SEARCH_TYPE = "Returned search type does not match expected type";
     private static final String VALIDATION_SEARCH_VALUE = "Returned search value does not match expected value";
     private static final String VALIDATION_USER_ID = "Returned user ID does not match expected user ID";
+    private static final String VALIDATION_CASE_NAME = "Returned case name does not match expected case name";
+    private static final String VALIDATION_CASE_NUMBER = "Returned case number does not match expected case number";
+    private static final String VALIDATION_CASE_URN = "Returned URN does not match expected URN";
+    private static final String VALIDATION_COURT_NAME = "Returned court name does not match expected court name";
 
     private static final String COURT_ID = "53";
     private static final String CASE_ID = "T485913";
@@ -77,7 +80,6 @@ class SubscriptionControllerTest {
     protected MockHttpServletRequestBuilder setupMockSubscription(String searchValue) throws JsonProcessingException {
 
         SUBSCRIPTION.setSearchValue(searchValue);
-        SUBSCRIPTION.setCourtName(COURT_NAME_1);
         SUBSCRIPTION.setCaseName(CASE_NAME);
         SUBSCRIPTION.setCaseNumber(CASE_ID);
         SUBSCRIPTION.setUrn(CASE_URN);
@@ -100,7 +102,7 @@ class SubscriptionControllerTest {
     @DisplayName("Post a new subscription and then get it from db.")
     @Test
     void postEndpoint() throws Exception {
-        MockHttpServletRequestBuilder mappedSubscription = setupMockSubscription(COURT_NAME_1);
+        MockHttpServletRequestBuilder mappedSubscription = setupMockSubscription(COURT_ID);
 
         MvcResult response = mvc.perform(mappedSubscription).andExpect(status().isCreated()).andReturn();
         assertNotNull(response.getResponse().getContentAsString(), VALIDATION_EMPTY_RESPONSE);
@@ -138,12 +140,20 @@ class SubscriptionControllerTest {
         assertNotEquals(
             returnedSubscription.getId(), 0L, "id should not equal zero"
         );
+        assertEquals(SUBSCRIPTION.getCaseName(), returnedSubscription.getCaseName(),
+                     VALIDATION_CASE_NAME);
+        assertEquals(SUBSCRIPTION.getCaseNumber(), returnedSubscription.getCaseNumber(),
+                     VALIDATION_CASE_NUMBER);
+        assertEquals(SUBSCRIPTION.getUrn(), returnedSubscription.getUrn(),
+                     VALIDATION_CASE_URN);
+        assertEquals(COURT_NAME_1, returnedSubscription.getCourtName(),
+                     VALIDATION_COURT_NAME);
     }
 
     @DisplayName("Ensure post endpoint actually posts a subscription to db")
     @Test
     void checkPostToDb() throws Exception {
-        MockHttpServletRequestBuilder mappedSubscription = setupMockSubscription(COURT_NAME_1);
+        MockHttpServletRequestBuilder mappedSubscription = setupMockSubscription(COURT_ID);
 
         MvcResult response = mvc.perform(mappedSubscription).andExpect(status().isCreated()).andReturn();
         assertNotNull(response.getResponse().getContentAsString(), VALIDATION_EMPTY_RESPONSE);
@@ -190,6 +200,14 @@ class SubscriptionControllerTest {
         assertNotEquals(
             returnedSubscription2.getId(), 0L, "id should not equal zero"
         );
+        assertEquals(SUBSCRIPTION.getCaseName(), returnedSubscription.getCaseName(),
+                     VALIDATION_CASE_NAME);
+        assertEquals(SUBSCRIPTION.getCaseNumber(), returnedSubscription.getCaseNumber(),
+                     VALIDATION_CASE_NUMBER);
+        assertEquals(SUBSCRIPTION.getUrn(), returnedSubscription.getUrn(),
+                     VALIDATION_CASE_URN);
+        assertEquals(COURT_NAME_1, returnedSubscription.getCourtName(),
+                     VALIDATION_COURT_NAME);
 
     }
 
@@ -223,7 +241,7 @@ class SubscriptionControllerTest {
     @DisplayName("Delete an individual subscription")
     @Test
     void deleteEndpoint() throws Exception {
-        MockHttpServletRequestBuilder mappedSubscription = setupMockSubscription(COURT_NAME_1);
+        MockHttpServletRequestBuilder mappedSubscription = setupMockSubscription(COURT_ID);
 
         MvcResult response = mvc.perform(mappedSubscription).andExpect(status().isCreated()).andReturn();
         assertNotNull(response.getResponse().getContentAsString(), VALIDATION_EMPTY_RESPONSE);
@@ -243,7 +261,7 @@ class SubscriptionControllerTest {
         ))).andExpect(status().isOk()).andReturn();
         assertNotNull(deleteResponse.getResponse(), VALIDATION_EMPTY_RESPONSE);
         assertEquals(
-            String.format("Subscription: %s was deleted", returnedSubscription.getId()),
+            String.format("Subscription: %s deleted", returnedSubscription.getId()),
             deleteResponse.getResponse().getContentAsString(),
             "Responses are not equal"
         );

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.pip.subscription.management.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.client.RestTemplate;
+
+@Profile("!test")
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,15 +36,15 @@ public class SubscriptionController {
     @ApiOperation("Endpoint to create a new unique subscription - the 'id' field is hidden from swagger as it is auto"
         + " generated on creation")
     @ApiResponses({
-        @ApiResponse(code = 200, message = "Subscription successfully created with the id: {subscription id} "
+        @ApiResponse(code = 201, message = "Subscription successfully created with the id: {subscription id} "
             + "for user: {userId}"),
         @ApiResponse(code = 400, message = "This subscription object has an invalid format. Please check again.")
     })
     public ResponseEntity<String> createSubscription(@RequestBody @Valid SubscriptionDto sub) {
         Subscription subscription = subscriptionService.createSubscription(sub.toEntity());
-        return ResponseEntity.ok(String.format("Subscription created with the id %s for user '%s'",
-                                               subscription.getId(), subscription.getUserId()
-        ));
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(String.format("Subscription created with the id %s for user '%s'",
+                                                        subscription.getId(), subscription.getUserId()));
     }
 
     @ApiResponses({

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionController.java
@@ -59,7 +59,7 @@ public class SubscriptionController {
                              @PathVariable UUID subId) {
 
         subscriptionService.deleteById(subId);
-        return String.format("Subscription %s deleted", subId);
+        return String.format("Subscription: %s deleted", subId);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/Subscription.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/Subscription.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import org.hibernate.annotations.Type;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -49,6 +50,21 @@ public class Subscription {
     @Enumerated(EnumType.STRING)
     private Channel channel;
 
+    @ApiModelProperty(hidden = true)
+    private LocalDateTime createdDate = LocalDateTime.now();
+
+    @Valid
+    private String caseNumber;
+
+    @Valid
+    private String caseName;
+
+    @Valid
+    private String urn;
+
+    @Valid
+    private String courtName;
+
     public SubscriptionDto toDto() {
         SubscriptionDto dto = new SubscriptionDto();
         dto.setSearchValue(this.searchValue);
@@ -56,6 +72,11 @@ public class Subscription {
         dto.setUserId(this.userId);
         dto.setSearchType(this.searchType);
         dto.setId(this.id);
+        dto.setCreatedDate(this.createdDate);
+        dto.setCaseNumber(this.caseNumber);
+        dto.setCaseName(this.caseName);
+        dto.setUrn(this.urn);
+        dto.setCourtName(this.courtName);
         return dto;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/SubscriptionDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/SubscriptionDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -44,6 +45,19 @@ public class SubscriptionDto {
     @NotNull
     private Channel channel;
 
+    private LocalDateTime createdDate = LocalDateTime.now();
+
+    @Valid
+    private String caseNumber;
+
+    @Valid
+    private String caseName;
+
+    @Valid
+    private String urn;
+
+    @Valid
+    private String courtName;
 
     public Subscription toEntity() {
         Subscription entity = new Subscription();
@@ -52,6 +66,11 @@ public class SubscriptionDto {
         entity.setUserId(this.userId);
         entity.setSearchType(this.searchType);
         entity.setId(this.id);
+        entity.setCreatedDate(this.createdDate);
+        entity.setCaseName(this.caseName);
+        entity.setCaseNumber(this.caseNumber);
+        entity.setUrn(this.urn);
+        entity.setCourtName(this.courtName);
         return entity;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/DataManagementService.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.pip.subscription.management.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class DataManagementService {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${service-to-service.data-management}")
+    private String url;
+
+
+    public String getCourtName(String courtId) {
+        try {
+            ResponseEntity<JsonNode> response = this.restTemplate.getForEntity(
+                String.format("%s/courts/%s", url, courtId), JsonNode.class);
+            return response.getBody().path("name").asText();
+        } catch (HttpStatusCodeException ex) {
+            log.error("Data management request failed for CourtId: {}. Response: {}",
+                      courtId, ex.getResponseBodyAsString());
+            return null;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.pip.subscription.management.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.pip.subscription.management.errorhandling.exceptions.SubscriptionNotFoundException;
+import uk.gov.hmcts.reform.pip.subscription.management.models.SearchType;
 import uk.gov.hmcts.reform.pip.subscription.management.models.Subscription;
 import uk.gov.hmcts.reform.pip.subscription.management.repository.SubscriptionRepository;
 
@@ -19,8 +20,14 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     @Autowired
     SubscriptionRepository repository;
 
+    @Autowired
+    DataManagementService dataManagementService;
+
     @Override
     public Subscription createSubscription(Subscription subscription) {
+        if (subscription.getSearchType().equals(SearchType.COURT_ID)) {
+            subscription.setCourtName(dataManagementService.getCourtName(subscription.getSearchValue()));
+        }
         return repository.save(subscription);
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,6 +47,9 @@ spring:
       # this ensures the db persists after spring boot connection drops.
       ddl-auto: update
 
+service-to-service:
+  data-management: ${DATA_MANAGEMENT_URL:https://pip-data-management.staging.platform.hmcts.net}
 azure:
+
   application-insights:
     instrumentation-key: ${rpe.AppInsightsInstrumentationKey:00000000-0000-0000-0000-000000000000}

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateConfigTest.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.pip.subscription.management.config;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfigTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    public RestTemplateConfigTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return restTemplate;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateConfigTest.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfigTest {
 
     @Mock
-    private RestTemplate restTemplate;
+    private RestTemplate mockRestTemplate;
 
     public RestTemplateConfigTest() {
         MockitoAnnotations.openMocks(this);
@@ -18,6 +18,6 @@ public class RestTemplateConfigTest {
 
     @Bean
     public RestTemplate restTemplate() {
-        return restTemplate;
+        return mockRestTemplate;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/config/RestTemplateTest.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.pip.subscription.management.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class RestTemplateTest {
+
+    @Test
+    void testGetConfig() {
+        RestTemplate restTemplate = new RestTemplateConfig().restTemplate();
+        assertNotNull(restTemplate, "Rest Template config has not created a rest template");
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
@@ -7,6 +7,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.pip.subscription.management.helpers.SubscriptionHelper;
 import uk.gov.hmcts.reform.pip.subscription.management.models.Subscription;
@@ -45,10 +46,9 @@ class SubscriptionControllerTest {
     void testCreateSubscription() {
         when(subscriptionService.createSubscription(mockSubscription))
             .thenReturn(mockSubscription);
-        assertEquals(subscriptionController.createSubscription(mockSubscription.toDto()),
-                     ResponseEntity.ok(String.format("Subscription created with the id %s for user '%s'",
-                                                     mockSubscription.getId(), mockSubscription.getUserId()
-                     )),
+        assertEquals(new ResponseEntity<>(String.format("Subscription created with the id %s for user '%s'",
+                                                          mockSubscription.getId(), mockSubscription.getUserId()), HttpStatus.CREATED),
+                     subscriptionController.createSubscription(mockSubscription.toDto()),
                      "Returned subscription does not match expected subscription"
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/controllers/SubscriptionControllerTest.java
@@ -47,7 +47,8 @@ class SubscriptionControllerTest {
         when(subscriptionService.createSubscription(mockSubscription))
             .thenReturn(mockSubscription);
         assertEquals(new ResponseEntity<>(String.format("Subscription created with the id %s for user '%s'",
-                                                          mockSubscription.getId(), mockSubscription.getUserId()), HttpStatus.CREATED),
+                                                          mockSubscription.getId(), mockSubscription.getUserId()),
+                                          HttpStatus.CREATED),
                      subscriptionController.createSubscription(mockSubscription.toDto()),
                      "Returned subscription does not match expected subscription"
         );

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/DataManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/DataManagementServiceTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.pip.subscription.management.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.pip.subscription.management.Application;
+import uk.gov.hmcts.reform.pip.subscription.management.config.RestTemplateConfigTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = {RestTemplateConfigTest.class, Application.class})
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class DataManagementServiceTest {
+
+    private static final String COURT_URL = "testUrl/courts/";
+    private static final String VALID_CASE_ID = "123";
+    private static final String VALID_URN = "321";
+    private static final String VALID_COURT_ID = "345";
+    private static final String VALID_CASE_NAME = "court-name";
+    private static final String INVALID = "test";
+
+    private JsonNode returnedCourt;
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    @Autowired
+    DataManagementService dataManagementService;
+
+
+    @BeforeEach
+    void setup() {
+        returnedCourt = new JsonNodeFactory(false).textNode("test court name");
+
+        when(restTemplate.getForEntity(COURT_URL + VALID_COURT_ID, JsonNode.class))
+            .thenReturn(ResponseEntity.ok(returnedCourt));
+        doThrow(HttpStatusCodeException.class).when(restTemplate).getForEntity(COURT_URL + INVALID, JsonNode.class);
+    }
+
+    @Test
+    void testGetCourt() {
+        assertEquals(returnedCourt.asText(), dataManagementService.getCourtName(VALID_COURT_ID),
+                     "Should match the returned court on successful GET"
+        );
+    }
+
+    @Test
+    void testGetCourtThrows() {
+        String returned = "";
+        try {
+            returned = dataManagementService.getCourtName(INVALID);
+        } catch (HttpStatusCodeException ex) {
+            assertNull(returned);
+        }
+        assertNull(dataManagementService.getCourtName(INVALID));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/DataManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/DataManagementServiceTest.java
@@ -2,15 +2,17 @@ package uk.gov.hmcts.reform.pip.subscription.management.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.pip.subscription.management.Application;
 import uk.gov.hmcts.reform.pip.subscription.management.config.RestTemplateConfigTest;
@@ -26,13 +28,10 @@ import static org.mockito.Mockito.when;
 class DataManagementServiceTest {
 
     private static final String COURT_URL = "testUrl/courts/";
-    private static final String VALID_CASE_ID = "123";
-    private static final String VALID_URN = "321";
     private static final String VALID_COURT_ID = "345";
-    private static final String VALID_CASE_NAME = "court-name";
     private static final String INVALID = "test";
 
-    private JsonNode returnedCourt;
+    private ObjectNode returnedCourt;
 
     @Autowired
     RestTemplate restTemplate;
@@ -43,29 +42,25 @@ class DataManagementServiceTest {
 
     @BeforeEach
     void setup() {
-        returnedCourt = new JsonNodeFactory(false).textNode("test court name");
-
+        returnedCourt = new JsonNodeFactory(false).objectNode();
+        returnedCourt.put("name", "test court name");
         when(restTemplate.getForEntity(COURT_URL + VALID_COURT_ID, JsonNode.class))
             .thenReturn(ResponseEntity.ok(returnedCourt));
-        doThrow(HttpStatusCodeException.class).when(restTemplate).getForEntity(COURT_URL + INVALID, JsonNode.class);
+        HttpServerErrorException httpServerErrorException =
+            new HttpServerErrorException(HttpStatus.BAD_GATEWAY, "Bad Gateway", null, null);
+        doThrow(httpServerErrorException).when(restTemplate).getForEntity(COURT_URL + INVALID, JsonNode.class);
     }
 
     @Test
     void testGetCourt() {
-        assertEquals(returnedCourt.asText(), dataManagementService.getCourtName(VALID_COURT_ID),
+        assertEquals(returnedCourt.get("name").asText(), dataManagementService.getCourtName(VALID_COURT_ID),
                      "Should match the returned court on successful GET"
         );
     }
 
     @Test
     void testGetCourtThrows() {
-        String returned = "";
-        try {
-            returned = dataManagementService.getCourtName(INVALID);
-        } catch (HttpStatusCodeException ex) {
-            assertNull(returned);
-        }
-        assertNull(dataManagementService.getCourtName(INVALID));
+        assertNull(dataManagementService.getCourtName(INVALID), "Should return null on errored call");
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.pip.subscription.management.errorhandling.exceptions.SubscriptionNotFoundException;
+import uk.gov.hmcts.reform.pip.subscription.management.models.SearchType;
 import uk.gov.hmcts.reform.pip.subscription.management.models.Subscription;
 import uk.gov.hmcts.reform.pip.subscription.management.repository.SubscriptionRepository;
 
@@ -32,6 +33,8 @@ class SubscriptionServiceTest {
     private Subscription mockSubscription;
     private Subscription findableSubscription;
 
+    @Mock
+    DataManagementService dataManagementService;
 
     @Mock
     SubscriptionRepository subscriptionRepository;
@@ -55,6 +58,17 @@ class SubscriptionServiceTest {
 
     @Test
     void testCreateSubscription() {
+        mockSubscription.setSearchType(SearchType.CASE_ID);
+        when(subscriptionRepository.save(mockSubscription)).thenReturn(mockSubscription);
+        assertEquals(subscriptionService.createSubscription(mockSubscription), mockSubscription,
+                     "The returned subscription does not match the expected subscription"
+        );
+    }
+
+    @Test
+    void testCreateSubscriptionWithCourtName() {
+        mockSubscription.setSearchType(SearchType.COURT_ID);
+        when(dataManagementService.getCourtName(SEARCH_VALUE)).thenReturn("test court name");
         when(subscriptionRepository.save(mockSubscription)).thenReturn(mockSubscription);
         assertEquals(subscriptionService.createSubscription(mockSubscription), mockSubscription,
                      "The returned subscription does not match the expected subscription"

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,2 @@
+service-to-service:
+  data-management: testUrl


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-738


### Change description ###
Updated the creation of subscriptions.

### model updates
the subscription object has been updated to include 4 extra fields on the db, these are:
Case Name
Case Number
URN
Court Name

### API call
the case attributes are passed in the payload when creating the object. the court name however is retrieved from data management. the plan for future is to pull the court name from reference table wherever that may end up being stored. in the mean time, it is pulled from the Court api in [Data Management](https://github.com/hmcts/pip-data-management#api). the name is then pulled from the response and placed in the subscription database. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
