### PR TITLE
PUB-1313 Stop duplicate subscriptions for a user

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -95,6 +95,7 @@
     <packageUrl regex="true">^pkg:maven/org.springframework.boot/spring-boot-starter-oauth2-client@2.5.14</packageUrl>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2021-22112</cve>
+    <cve>CVE-2022-22976</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -103,6 +104,7 @@
     <packageUrl regex="true">^pkg:maven/org.springframework.boot/spring-boot-starter-oauth2-resource-server@2.5.14</packageUrl>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2021-22112</cve>
+    <cve>CVE-2022-22976</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -115,5 +117,15 @@
     <notes><![CDATA[Spring old vuln thats been re-flagged recently, doesnt look like we are impacted]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework/spring.*$</packageUrl>
     <cve>CVE-2016-1000027</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[file name: spring-plugin-core-2.0.0.RELEASE.jar]]></notes>
+    <packageUrl regex="true">^pkg:maven/org.springframework.plugin/spring-plugin-core@2.0.0.RELEASE</packageUrl>
+    <cve>CVE-2022-22970</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[file name: spring-plugin-metadata-2.0.0.RELEASE.jar]]></notes>
+    <packageUrl regex="true">^pkg:maven/org.springframework.plugin/spring-plugin-metadata@2.0.0.RELEASE</packageUrl>
+    <cve>CVE-2022-22970</cve>
   </suppress>
 </suppressions>

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
@@ -36,6 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.pip.subscription.management.helpers.SubscriptionUtils.createMockSubscription;
 import static uk.gov.hmcts.reform.pip.subscription.management.helpers.SubscriptionUtils.createMockSubscriptionList;
@@ -159,6 +161,22 @@ class SubscriptionServiceTest {
         assertEquals(subscriptionService.createSubscription(mockSubscription), mockSubscription,
                      "The returned subscription does not match the expected subscription"
         );
+    }
+
+    @Test
+    void testCreateDuplicateSubscription() {
+        mockSubscription.setSearchType(SearchType.LOCATION_ID);
+        mockSubscription.setSearchValue(SEARCH_VALUE);
+        when(dataManagementService.getCourtName(SEARCH_VALUE)).thenReturn("test court name");
+        when(subscriptionRepository.save(mockSubscription)).thenReturn(mockSubscription);
+        when(subscriptionRepository.findByUserId(USER_ID)).thenReturn(List.of(mockSubscription));
+
+        Subscription returnedSubscription =
+            subscriptionService.createSubscription(mockSubscription);
+
+        verify(subscriptionRepository, times(1)).delete(mockSubscription);
+        assertEquals(returnedSubscription, mockSubscription,
+                     "The Returned subscription does match the expected subscription");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1313

### Change description ###

New method added called duplicateSubscriptionHandler which checks if any subscriptions match the same criteria as the new subscription being added, if there is then the existing one gets deleted and the new one supersedes it. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
