### PR TITLE
PUB-1513 Send deleted artefact information to publication services third party api endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/external/publication/services/ThirdPartySubscriptionArtefact.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/external/publication/services/ThirdPartySubscriptionArtefact.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.pip.subscription.management.models.external.data.management.Artefact;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ThirdPartySubscriptionArtefact {
+    String apiDestination;
+    Artefact artefact;
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/PublicationServicesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/PublicationServicesService.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.pip.subscription.management.models.Subscription;
 import uk.gov.hmcts.reform.pip.subscription.management.models.SubscriptionsSummary;
 import uk.gov.hmcts.reform.pip.subscription.management.models.SubscriptionsSummaryDetails;
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscriptionArtefact;
 
 import java.util.List;
 import java.util.UUID;
@@ -60,11 +61,11 @@ public class PublicationServicesService {
         }
     }
 
-    public String sendEmptyArtefact(String apiDestination) {
+    public String sendEmptyArtefact(ThirdPartySubscriptionArtefact subscriptionArtefact) {
         try {
             webClient.put().uri(url + NOTIFY_API_PATH)
                 .attributes(clientRegistrationId("publicationServicesApi"))
-                .bodyValue(apiDestination).retrieve()
+                .bodyValue(subscriptionArtefact).retrieve()
                 .bodyToMono(Void.class).block();
             return "Successfully sent";
         } catch (WebClientResponseException ex) {

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceImpl.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.pip.subscription.management.models.Subscription;
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.data.management.Artefact;
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.data.management.Sensitivity;
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscriptionArtefact;
 import uk.gov.hmcts.reform.pip.subscription.management.models.response.CaseSubscription;
 import uk.gov.hmcts.reform.pip.subscription.management.models.response.LocationSubscription;
 import uk.gov.hmcts.reform.pip.subscription.management.models.response.UserSubscription;
@@ -251,14 +252,16 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             subscriptionsToContact = subscriptionList;
         }
 
-        handleDeletedArtefactSending(subscriptionsToContact);
+        handleDeletedArtefactSending(subscriptionsToContact, artefactBeingDeleted);
     }
 
-    private void handleDeletedArtefactSending(List<Subscription> subscriptions) {
+    private void handleDeletedArtefactSending(List<Subscription> subscriptions, Artefact artefactBeingDeleted) {
         List<Subscription> apiList = sortSubscriptionByChannel(subscriptions,
                                                                Channel.API_COURTEL.notificationRoute);
 
         channelManagementService.getMappedApis(apiList).forEach((api, subscription) ->
-            log.info(writeLog(publicationServicesService.sendEmptyArtefact(api))));
+            log.info(writeLog(publicationServicesService.sendEmptyArtefact(
+                new ThirdPartySubscriptionArtefact(api, artefactBeingDeleted)
+            ))));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/PublicationServicesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/PublicationServicesServiceTest.java
@@ -18,7 +18,9 @@ import uk.gov.hmcts.reform.pip.subscription.management.models.SearchType;
 import uk.gov.hmcts.reform.pip.subscription.management.models.Subscription;
 import uk.gov.hmcts.reform.pip.subscription.management.models.SubscriptionsSummary;
 import uk.gov.hmcts.reform.pip.subscription.management.models.SubscriptionsSummaryDetails;
+import uk.gov.hmcts.reform.pip.subscription.management.models.external.data.management.Artefact;
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscriptionArtefact;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,6 +45,8 @@ class PublicationServicesServiceTest {
     private static final String TEST_ID = "123";
     private static final String RESULT_MATCH = "Returned strings should match";
     private static final String REQUEST_FAILED = "Request failed";
+    private static final String TEST_API_DESTINATION = "http://www.abc.com";
+    private static final Artefact TEST_ARTEFACT = new Artefact();
 
     private final SubscriptionsSummary subscriptionsSummary = new SubscriptionsSummary();
     private final Subscription subscription = new Subscription();
@@ -114,7 +118,7 @@ class PublicationServicesServiceTest {
                                                     .addHeader(CONTENT_TYPE, ContentType.APPLICATION_JSON)
                                                     .setResponseCode(200));
         assertEquals("Successfully sent", publicationServicesService
-            .sendThirdPartyList(new ThirdPartySubscription("test", UUID.randomUUID())),
+            .sendThirdPartyList(new ThirdPartySubscription(TEST_API_DESTINATION, UUID.randomUUID())),
                      RESULT_MATCH);
     }
 
@@ -124,7 +128,8 @@ class PublicationServicesServiceTest {
                                                     .addHeader(CONTENT_TYPE, ContentType.APPLICATION_JSON)
                                                     .setResponseCode(200));
 
-        assertEquals("Successfully sent", publicationServicesService.sendEmptyArtefact(TEST_ID), RESULT_MATCH);
+        assertEquals("Successfully sent", publicationServicesService.sendEmptyArtefact(
+            new ThirdPartySubscriptionArtefact(TEST_API_DESTINATION, TEST_ARTEFACT)), RESULT_MATCH);
     }
 
     @Test
@@ -133,7 +138,8 @@ class PublicationServicesServiceTest {
                                                     .setResponseCode(404));
 
         try (LogCaptor logCaptor = LogCaptor.forClass(PublicationServicesService.class)) {
-            assertEquals(REQUEST_FAILED, publicationServicesService.sendEmptyArtefact(TEST_ID), RESULT_MATCH);
+            assertEquals(REQUEST_FAILED, publicationServicesService.sendEmptyArtefact(
+                new ThirdPartySubscriptionArtefact(TEST_API_DESTINATION, TEST_ARTEFACT)), RESULT_MATCH);
             assertTrue(logCaptor.getErrorLogs().get(0).contains("Request to Publication Services /notify/api failed"),
                        "Log message does not contain expected message");
         }
@@ -143,7 +149,7 @@ class PublicationServicesServiceTest {
     void testSendThirdPartyListReturnsFailed() {
         mockPublicationServicesEndpoint.enqueue(new MockResponse().setResponseCode(404));
         assertEquals("Request failed", publicationServicesService
-                         .sendThirdPartyList(new ThirdPartySubscription("test", UUID.randomUUID())),
+                         .sendThirdPartyList(new ThirdPartySubscription(TEST_API_DESTINATION, UUID.randomUUID())),
                      "Messages match");
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.pip.subscription.management.models.external.data.mana
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.data.management.ListType;
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.data.management.Sensitivity;
 import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscription;
+import uk.gov.hmcts.reform.pip.subscription.management.models.external.publication.services.ThirdPartySubscriptionArtefact;
 import uk.gov.hmcts.reform.pip.subscription.management.models.response.CaseSubscription;
 import uk.gov.hmcts.reform.pip.subscription.management.models.response.LocationSubscription;
 import uk.gov.hmcts.reform.pip.subscription.management.models.response.UserSubscription;
@@ -27,6 +28,7 @@ import uk.gov.hmcts.reform.pip.subscription.management.repository.SubscriptionRe
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -495,13 +497,15 @@ class SubscriptionServiceTest {
     @Test
     void testCollectThirdPartyForDeletion() {
         mockSubscription.setChannel(Channel.API_COURTEL);
-        Map<String, List<Subscription>> returnedMap = new ConcurrentHashMap<>();
-        returnedMap.put(TEST, List.of(mockSubscription));
+        Map<String, List<Subscription>> returnedMap = Collections.singletonMap(TEST, List.of(mockSubscription));
         when(subscriptionRepository.findSubscriptionsBySearchValue(SearchType.LIST_TYPE.toString(),
                                                                    publicArtefactMatches.getListType().name()))
             .thenReturn(List.of(mockSubscription));
         when(channelManagementService.getMappedApis(List.of(mockSubscription))).thenReturn(returnedMap);
-        when(publicationServicesService.sendEmptyArtefact(TEST)).thenReturn(SUBSCRIBER_NOTIFICATION_LOG);
+        ThirdPartySubscriptionArtefact subscriptionArtefact = new ThirdPartySubscriptionArtefact(
+            TEST, publicArtefactMatches);
+        when(publicationServicesService.sendEmptyArtefact(subscriptionArtefact))
+            .thenReturn(SUBSCRIBER_NOTIFICATION_LOG);
         try (LogCaptor logCaptor = LogCaptor.forClass(SubscriptionServiceImpl.class)) {
             subscriptionService.collectThirdPartyForDeletion(publicArtefactMatches);
             assertTrue(logCaptor.getInfoLogs().get(0).contains(SUBSCRIBER_NOTIFICATION_LOG),
@@ -512,17 +516,16 @@ class SubscriptionServiceTest {
     @Test
     void testCollectThirdPartyForDeletionClassifiedExcluded() {
         mockSubscription.setChannel(Channel.API_COURTEL);
-        Map<String, List<Subscription>> returnedMap = new ConcurrentHashMap<>();
-        returnedMap.put(TEST, List.of(mockSubscription));
-        lenient().when(subscriptionRepository.findSubscriptionsBySearchValue(SearchType.LIST_TYPE.toString(),
+        when(subscriptionRepository.findSubscriptionsBySearchValue(SearchType.LIST_TYPE.toString(),
                                                                    classifiedArtefactMatches.getListType().name()))
             .thenReturn(List.of(mockSubscription));
-        lenient().when(channelManagementService.getMappedApis(List.of(mockSubscription))).thenReturn(returnedMap);
-        lenient().when(publicationServicesService.sendEmptyArtefact(TEST)).thenReturn(SUCCESS);
-        lenient().when(accountManagementService.isUserAuthorised(mockSubscription.getUserId(),
+        when(accountManagementService.isUserAuthorised(mockSubscription.getUserId(),
                                                        classifiedArtefactMatches.getListType(),
                                                        classifiedArtefactMatches.getSensitivity())).thenReturn(false);
-        verify(publicationServicesService, never()).sendEmptyArtefact(TEST);
+        subscriptionService.collectThirdPartyForDeletion(classifiedArtefactMatches);
+        ThirdPartySubscriptionArtefact subscriptionArtefact = new ThirdPartySubscriptionArtefact(
+            TEST, classifiedArtefactMatches);
+        verify(publicationServicesService, never()).sendEmptyArtefact(subscriptionArtefact);
     }
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1513

### Change description ###

Send deleted artefact information to publication services third party api endpoint, this is then used to construct the request headers before sending it through to Courtel

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
