### PR TITLE
Force upgrade snakeyaml version for CVE-2022-25857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,12 @@ dependencies {
   }
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-webflux', version: '2.6.4'
   implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'
+
+  // Force upgrade snakeyaml version for CVE-2022-25857
+  implementation( group: 'org.yaml', name: 'snakeyaml').version {
+    strictly("1.31")
+  }
+
   testImplementation(platform('org.junit:junit-bom:5.8.1'))
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
     exclude group: 'junit', module: 'junit'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://nvd.nist.gov/vuln/detail/CVE-2022-25857

### Change description ###

Force upgrade snakeyaml version for CVE-2022-25857

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
