### PR TITLE
PUB-1598 Upgrade HMCTS logging components to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ repositories {
 }
 
 ext {
-  reformLoggingVersion = "5.1.9"
+  reformLoggingVersion = "6.0.1"
 }
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
@@ -195,6 +195,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
+  implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.2'
 
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-active-directory', version: '4.4.1'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.1'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1598

### Change description ###

Upgrade HMCTS logging components to latest version. 

We have to bring a new dependency "logstash-logback-encoder" into the project because java-logging-appinsights are using an Appender from logstash in their XML config. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
