### PR TITLE
PUB-2002 - Added partyName field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencies {
 
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-active-directory', version: '4.7.0'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
-  implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.0.3', {
+  implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.0.4', {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-jpa'
   }
   implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.11.0'

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/Subscription.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/Subscription.java
@@ -76,6 +76,9 @@ public class Subscription {
     private String caseName;
 
     @Valid
+    private String partyNames;
+
+    @Valid
     private String urn;
 
     @Valid
@@ -98,6 +101,7 @@ public class Subscription {
         this.createdDate = dto.getCreatedDate();
         this.caseNumber = dto.getCaseNumber();
         this.caseName = dto.getCaseName();
+        this.partyNames = dto.getPartyNames();
         this.urn = dto.getUrn();
         this.locationName = dto.getLocationName();
         this.lastUpdatedDate = dto.getLastUpdatedDate();
@@ -115,6 +119,7 @@ public class Subscription {
         dto.setCreatedDate(this.createdDate);
         dto.setCaseNumber(this.caseNumber);
         dto.setCaseName(this.caseName);
+        dto.setPartyNames(this.partyNames);
         dto.setUrn(this.urn);
         dto.setLocationName(this.locationName);
         dto.setListType(this.listType);

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/response/CaseSubscription.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/models/response/CaseSubscription.java
@@ -10,6 +10,7 @@ public class CaseSubscription {
 
     private UUID subscriptionId;
     private String caseName;
+    private String partyNames;
     private String caseNumber;
     private String urn;
     private LocalDateTime dateAdded;

--- a/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/UserSubscriptionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/subscription/management/service/UserSubscriptionService.java
@@ -72,6 +72,7 @@ public class UserSubscriptionService {
                     caseSubscription.setSubscriptionId(subscription.getId());
                     caseSubscription.setCaseNumber(subscription.getCaseNumber());
                     caseSubscription.setUrn(subscription.getUrn());
+                    caseSubscription.setPartyNames(subscription.getPartyNames());
                     caseSubscription.setDateAdded(subscription.getCreatedDate());
                     userSubscription.getCaseSubscriptions().add(caseSubscription);
                 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/UserSubscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/UserSubscriptionServiceTest.java
@@ -32,6 +32,8 @@ class UserSubscriptionServiceTest {
     private static final String USER_ID_NO_SUBS = "Tina21";
     private static final String SEARCH_VALUE = "193254";
     private static final String CASE_ID = "123";
+
+    private static final String PARTY_NAMES = "Party A, Party B";
     private static final String URN = "312";
     private static final String CASE_NAME = "case-name";
     private static final Channel EMAIL = Channel.EMAIL;
@@ -86,12 +88,14 @@ class UserSubscriptionServiceTest {
         mockSubscription.setSearchType(SearchType.CASE_ID);
         mockSubscription.setCaseNumber(CASE_ID);
         mockSubscription.setCaseName(CASE_NAME);
+        mockSubscription.setPartyNames(PARTY_NAMES);
         mockSubscription.setUrn(URN);
 
         CaseSubscription expected = new CaseSubscription();
         expected.setCaseNumber(CASE_ID);
         expected.setCaseName(CASE_NAME);
         expected.setUrn(URN);
+        expected.setPartyNames(PARTY_NAMES);
         expected.setSubscriptionId(mockSubscription.getId());
         expected.setDateAdded(DATE_ADDED);
         when(subscriptionRepository.findByUserId(USER_ID)).thenReturn(List.of(mockSubscription));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2002

### Change description ###

Note - This build will not pass until https://github.com/hmcts/pip-data-models/pull/44 has been merged in

Added in party name response / storage into subscription management

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
