### PR TITLE
PUB-2119 - Updated dependencies + suppressions

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,7 +2,7 @@
 
 properties([
   // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-  pipelineTriggers([cron('H 07 * * 1-5')])
+  pipelineTriggers([cron('H 08 * * 1-5')])
 ])
 
 @Library("Infrastructure")

--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,7 @@ dependencies {
 
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-active-directory', version: '5.2.0'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
-  implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.1.1', {
+  implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.1.2', {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-jpa'
   }
   implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.11.0'

--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,7 @@ dependencies {
 
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-active-directory', version: '5.3.0'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
-  implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.1.2', {
+  implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.1.4', {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-jpa'
   }
   implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.11.0'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'org.sonarqube' version '4.3.0.3225'
   id 'com.github.ben-manes.versions' version '0.47.0'
   id 'io.freefair.lombok' version '8.1.0'
-  id 'org.jetbrains.kotlin.jvm' version '1.8.22'
+  id 'org.jetbrains.kotlin.jvm' version '1.9.0'
   id 'org.flywaydb.flyway' version '9.21.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@ plugins {
   id 'checkstyle'
   id 'pmd'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.1.0'
-  id 'org.springframework.boot' version '3.0.9'
+  id 'io.spring.dependency-management' version '1.1.2'
+  id 'org.springframework.boot' version '3.1.2'
   id 'org.owasp.dependencycheck' version '8.3.1'
-  id 'org.sonarqube' version '4.2.1.3168'
+  id 'org.sonarqube' version '4.3.0.3225'
   id 'com.github.ben-manes.versions' version '0.47.0'
   id 'io.freefair.lombok' version '8.1.0'
   id 'org.jetbrains.kotlin.jvm' version '1.8.22'
-  id 'org.flywaydb.flyway' version '9.20.0'
+  id 'org.flywaydb.flyway' version '9.21.1'
 }
 
 apply plugin: 'org.owasp.dependencycheck'
@@ -196,7 +196,7 @@ dependencies {
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
 
-  implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-active-directory', version: '5.2.0'
+  implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-active-directory', version: '5.3.0'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
   implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.1.2', {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-jpa'
@@ -207,14 +207,14 @@ dependencies {
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.2'
 
   // Include Flyway for database migrations
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.19.4'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.21.1'
 
   // Force upgrade snakeyaml version for CVE-2022-1471
   implementation( group: 'org.yaml', name: 'snakeyaml').version {
     strictly("2.0")
   }
 
-  testImplementation(platform('org.junit:junit-bom:5.9.3'))
+  testImplementation(platform('org.junit:junit-bom:5.10.0'))
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.0'
-  id 'org.springframework.boot' version '3.0.8'
+  id 'org.springframework.boot' version '3.0.9'
   id 'org.owasp.dependencycheck' version '8.3.1'
   id 'org.sonarqube' version '4.2.1.3168'
   id 'com.github.ben-manes.versions' version '0.47.0'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.2'
-  id 'org.springframework.boot' version '3.1.2'
+  id 'org.springframework.boot' version '3.0.9'
   id 'org.owasp.dependencycheck' version '8.3.1'
   id 'org.sonarqube' version '4.3.0.3225'
   id 'com.github.ben-manes.versions' version '0.47.0'

--- a/charts/pip-subscription-management/Chart.yaml
+++ b/charts/pip-subscription-management/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS PIP Team
 dependencies:
   - name: java
-    version: 4.1.4
+    version: 4.1.5
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,7 +9,7 @@
   </suppress>
   <suppress>
     <notes>The vulnerability exists in the latest version of lib too. Need to wait for new version with the fix</notes>
-    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2</packageUrl>
+    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.3</packageUrl>
     <cve>CVE-2023-35116</cve>
   </suppress>
   <suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,4 +17,14 @@
     <packageUrl regex="true">^pkg:maven/io.netty/netty-.*$</packageUrl>
     <cve>CVE-2023-34462</cve>
   </suppress>
+  <suppress>
+    <notes>Already on latest version of okhttp</notes>
+    <packageUrl regex="true">^pkg:maven/com.squareup.okhttp3/okhttp@4.11.0</packageUrl>
+    <cve>CVE-2023-3782</cve>
+  </suppress>
+  <suppress>
+    <notes>Pulled in by okhttp (which we're already on the latest version of)</notes>
+    <packageUrl regex="true">^pkg:maven/com.squareup.okio/okio-jvm@3.2.0</packageUrl>
+    <cve>CVE-2023-3635</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,20 +2,15 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes><![CDATA[
-   file name: spring-cloud-azure-starter-active-directory-5.2.0.jar
+   file name: spring-cloud-azure-starter-active-directory-5.3.0.jar
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com.azure.spring/spring-cloud-azure-starter-active-directory@5.2.0</packageUrl>
+    <packageUrl regex="true">^pkg:maven/com.azure.spring/spring-cloud-azure-starter-active-directory@5.3.0</packageUrl>
     <cve>CVE-2021-42306</cve>
   </suppress>
   <suppress>
     <notes>The vulnerability exists in the latest version of lib too. Need to wait for new version with the fix</notes>
-    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.3</packageUrl>
+    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2</packageUrl>
     <cve>CVE-2023-35116</cve>
-  </suppress>
-  <suppress>
-    <notes>Pull in by spring boot. The latest version of spring boot v3.1.1 is still using netty v4.1.93 where the vulnerability still exists</notes>
-    <packageUrl regex="true">^pkg:maven/io.netty/netty-.*$</packageUrl>
-    <cve>CVE-2023-34462</cve>
   </suppress>
   <suppress>
     <notes>Already on latest version of okhttp</notes>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
-
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/subscription/management/service/SubscriptionServiceTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.pip.subscription.management.models.Subscription;
 import uk.gov.hmcts.reform.pip.subscription.management.repository.SubscriptionRepository;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -73,7 +72,7 @@ class SubscriptionServiceTest {
     private Subscription findableSubscription;
 
     @Captor
-    private ArgumentCaptor<ArrayList<UUID>> listCaptor;
+    private ArgumentCaptor<List<UUID>> listCaptor;
 
     @Mock
     DataManagementService dataManagementService;
@@ -220,9 +219,10 @@ class SubscriptionServiceTest {
         List<UUID> testIds = List.of(testId1, testId2);
         List<Subscription> subscriptions = List.of(subscription1, subscription2);
 
-        doNothing().when(subscriptionRepository).deleteByIdIn(listCaptor.capture());
         when(subscriptionRepository.findByIdIn(testIds)).thenReturn(subscriptions);
         subscriptionService.bulkDeleteSubscriptions(testIds);
+
+        verify(subscriptionRepository).deleteByIdIn(listCaptor.capture());
         assertThat(listCaptor.getValue())
             .as("Subscription IDs to delete do not match")
             .isEqualTo(testIds);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2119

### Change description ###

Spring Dependency Management to 1.1.2
Sonarqube to 4.3.0.3225
Flyway plugin and core to 9.21.1
Kotlin JVM to 1.9.0
Active Directory starter to 5.3.0
jUnit to 5.10.0
Chart version to 4.1.5
Gradle version to 8.2.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
